### PR TITLE
recommend requesting permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ How this works:
 
 To use the `issue-from-pytest-log` action in workflows, simply add a new step:
 
+> [!WARNING]
+> The action won't run properly unless either `issues: write` permissions are requested as shown above or the actions are granted read/write permissions in the repository settings.
+
 ```yaml
 jobs:
   my-job:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ jobs:
       fail-fast: false
       ...
 
+    permissions:
+      # or set actions permissions in the repo settings to read/write
+      issues: write
+
     ...
 
     - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ How this works:
 To use the `issue-from-pytest-log` action in workflows, simply add a new step:
 
 > [!WARNING]
-> The action won't run properly unless either `issues: write` permissions are requested as shown below or the actions are granted read/write permissions in the repository settings.
+> The action won't run properly unless the `issues: write` permission is requested as shown below.
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ jobs:
 
     ...
 
-    - run: <
+    - run: |
         pip install --upgrade pytest-reportlog
 
     ...
 
-    - run: <
+    - run: |
         pytest --report-log pytest-log.jsonl
 
     ...

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ How this works:
 To use the `issue-from-pytest-log` action in workflows, simply add a new step:
 
 > [!WARNING]
-> The action won't run properly unless either `issues: write` permissions are requested as shown above or the actions are granted read/write permissions in the repository settings.
+> The action won't run properly unless either `issues: write` permissions are requested as shown below or the actions are granted read/write permissions in the repository settings.
 
 ```yaml
 jobs:
@@ -26,7 +26,6 @@ jobs:
       ...
 
     permissions:
-      # or set actions permissions in the repo settings to read/write
       issues: write
 
     ...


### PR DESCRIPTION
As it turns out, new repositories by default don't give workflows write access to the REST API, so we have to explicitly request that permission to be able to create issues.