### PR TITLE
strip ANSI escape codes from the output

### DIFF
--- a/parse_logs.py
+++ b/parse_logs.py
@@ -20,12 +20,11 @@ ansi_fe_escape_re = re.compile(
     rf"""
     \x1B # ESC
     (?:
-      {fe_bytes}  # single-byte Fe
-      |
       \[  # CSI
       {parameter_bytes}*
       {intermediate_bytes}*
-      {final_bytes}*
+      {final_bytes}
+      | {fe_bytes}  # single-byte Fe
     )
     """,
     re.VERBOSE,

--- a/parse_logs.py
+++ b/parse_logs.py
@@ -12,10 +12,29 @@ import more_itertools
 from pytest import CollectReport, TestReport
 
 test_collection_stage = "test collection session"
+fe_bytes = "[\x40-\x5f]"
+parameter_bytes = "[\x30-\x3f]"
+intermediate_bytes = "[\x20-\x2f]"
+final_bytes = "[\x40-\x7e]"
+ansi_fe_escape_re = re.compile(
+    rf"""
+    \x1B # ESC
+    (?:
+      {fe_bytes}  # single-byte Fe
+      |
+      \[  # CSI
+      {parameter_bytes}*
+      {intermediate_bytes}*
+      {final_bytes}*
+    )
+    """,
+    re.VERBOSE,
+)
 
 
 def strip_ansi(msg):
-    pass
+    """strip all ansi escape sequences"""
+    return ansi_fe_escape_re.sub("", msg)
 
 
 @dataclass

--- a/parse_logs.py
+++ b/parse_logs.py
@@ -14,6 +14,10 @@ from pytest import CollectReport, TestReport
 test_collection_stage = "test collection session"
 
 
+def strip_ansi(msg):
+    pass
+
+
 @dataclass
 class SessionStart:
     pytest_version: str
@@ -44,6 +48,9 @@ class PreformattedReport:
     name: str
     variant: str | None
     message: str
+
+    def __post_init__(self):
+        self.message = strip_ansi(self.message)
 
 
 @dataclass

--- a/test_parse_log.py
+++ b/test_parse_log.py
@@ -83,3 +83,11 @@ def test_strip_ansi(escape):
     message = f"some {escape}text"
 
     assert parse_logs.strip_ansi(message) == "some text"
+
+
+@given(ansi_fe_escapes())
+def test_preformatted_report_ansi(escape):
+    actual = parse_logs.PreformattedReport(
+        filepath="a", name="b", variant=None, message=f"{escape}text"
+    )
+    assert actual.message == "text"

--- a/test_parse_log.py
+++ b/test_parse_log.py
@@ -19,6 +19,30 @@ variants = st.from_regex(re.compile(r"(\w+-)*\w+"), fullmatch=True)
 messages = st.text()
 
 
+def ansi_csi_escapes():
+    parameter_bytes = st.lists(st.characters(min_codepoint=0x30, max_codepoint=0x3F))
+    intermediate_bytes = st.lists(st.characters(min_codepoint=0x20, max_codepoint=0x2F))
+    final_bytes = st.characters(min_codepoint=0x40, max_codepoint=0x7E)
+
+    return st.builds(
+        lambda *args: "".join(["\x1b[", *args]),
+        parameter_bytes.map("".join),
+        intermediate_bytes.map("".join),
+        final_bytes,
+    )
+
+
+def ansi_c1_escapes():
+    byte_ = st.characters(
+        codec="ascii", min_codepoint=0x40, max_codepoint=0x5F, exclude_characters=["["]
+    )
+    return st.builds(lambda b: f"\x1b{b}", byte_)
+
+
+def ansi_fe_escapes():
+    return ansi_csi_escapes() | ansi_c1_escapes()
+
+
 def preformatted_reports():
     return st.tuples(filepaths, names, variants | st.none(), messages).map(
         lambda x: parse_logs.PreformattedReport(*x)
@@ -47,3 +71,15 @@ def test_truncate(reports, max_chars):
     formatted = parse_logs.truncate(reports, max_chars=max_chars, py_version=py_version)
 
     assert formatted is None or len(formatted) <= max_chars
+
+
+@given(st.lists(ansi_fe_escapes()).map("".join))
+def test_strip_ansi_multiple(escapes):
+    assert parse_logs.strip_ansi(escapes) == ""
+
+
+@given(ansi_fe_escapes())
+def test_strip_ansi(escape):
+    message = f"some {escape}text"
+
+    assert parse_logs.strip_ansi(message) == "some text"


### PR DESCRIPTION
`pytest` somewhat recently has started to also add colours to the diffs of built-in structures (like `dict` or `list`), which means we see the escape codes in the created issue (setting the `CI` env var usually disables colours, but at least in the projects I work on we set `FORCE_COLORS` because it makes reading the output a lot easier).

To avoid that, we strip the escape sequences here.

Ideally I'd want to have `pytest-reportlog` do this for us (after all, `reportlog` is designed to be machine-readable), but this would take a while to roll out.